### PR TITLE
Fixed the display of the marker for the right image when in stereo mode

### DIFF
--- a/src/Unity/Assets/ARToolKit5-Unity/Scripts/ARCamera.cs
+++ b/src/Unity/Assets/ARToolKit5-Unity/Scripts/ARCamera.cs
@@ -204,7 +204,13 @@ public class ARCamera : MonoBehaviour
 				Matrix4x4 pose;
 				if (Optical && opticalSetupOK) {
 					pose = (opticalViewMatrix * marker.TransformationMatrix).inverse;
-				} else {
+				}
+				else if (StereoEye == ViewEye.Right)
+				{
+					pose = marker.TransformationMatrixR.inverse;
+				}
+				else
+				{
 					pose = marker.TransformationMatrix.inverse;
 				}
 				

--- a/src/Unity/Assets/ARToolKit5-Unity/Scripts/Editor/ARMarkerEditor.cs
+++ b/src/Unity/Assets/ARToolKit5-Unity/Scripts/Editor/ARMarkerEditor.cs
@@ -109,6 +109,8 @@ public class ARMarkerEditor : Editor
 			m.MarkerType = t;
 			m.Load();
 		}
+
+		m.videoIsStereo = EditorGUILayout.Toggle("Stereo augmentation", m.videoIsStereo);
 		
 		// Description of the type of marker
         EditorGUILayout.LabelField("Description", ARMarker.MarkerTypeNames[m.MarkerType]);


### PR DESCRIPTION
When in stereo mode in Unity it was not using the the correct projection matrix for the right camera.