### PR TITLE
Resolve build warnings in Unity 5.3

### DIFF
--- a/src/Unity/Assets/ARToolKit5-Unity/Scripts/ARController.cs
+++ b/src/Unity/Assets/ARToolKit5-Unity/Scripts/ARController.cs
@@ -342,9 +342,9 @@ public class ARController : MonoBehaviour
                 break;
             case RuntimePlatform.IPhonePlayer:                    // Unity Player on iOS.
                 break;
-            case RuntimePlatform.MetroPlayerX86:                // Unity Player on Windows Store X86.
-            case RuntimePlatform.MetroPlayerX64:                // Unity Player on Windows Store X64.
-            case RuntimePlatform.MetroPlayerARM:                // Unity Player on Windows Store ARM.
+            case RuntimePlatform.WSAPlayerX86:                  // Unity Player on Windows Store X86.
+            case RuntimePlatform.WSAPlayerX64:                  // Unity Player on Windows Store X64.
+            case RuntimePlatform.WSAPlayerARM:                  // Unity Player on Windows Store ARM.
                 PluginFunctions.arwRegisterLogCallback(Log);
                 break;
             default:
@@ -461,9 +461,9 @@ public class ARController : MonoBehaviour
                 break;
             case RuntimePlatform.IPhonePlayer:
                 break;
-            case RuntimePlatform.MetroPlayerX86:
-            case RuntimePlatform.MetroPlayerX64:
-            case RuntimePlatform.MetroPlayerARM:
+            case RuntimePlatform.WSAPlayerX86:
+            case RuntimePlatform.WSAPlayerX64:
+            case RuntimePlatform.WSAPlayerARM:
                 PluginFunctions.arwRegisterLogCallback(null);
                 break;
             default:
@@ -546,9 +546,9 @@ public class ARController : MonoBehaviour
                 videoConfiguration0 = videoConfigurationiOS0 + (_useNativeGLTexturing || !AllowNonRGBVideo ? " -format=BGRA" : "");
                 videoConfiguration1 = videoConfigurationiOS1 + (_useNativeGLTexturing || !AllowNonRGBVideo ? " -format=BGRA" : "");
                 break;
-            case RuntimePlatform.MetroPlayerX86:
-            case RuntimePlatform.MetroPlayerX64:
-            case RuntimePlatform.MetroPlayerARM:
+            case RuntimePlatform.WSAPlayerX86:
+            case RuntimePlatform.WSAPlayerX64:
+            case RuntimePlatform.WSAPlayerARM:
                 videoConfiguration0 = videoConfigurationWindowsStore0;
                 videoConfiguration1 = videoConfigurationWindowsStore1;
                 break;

--- a/src/Unity/Assets/ARToolKit5-Unity/Scripts/ARController.cs
+++ b/src/Unity/Assets/ARToolKit5-Unity/Scripts/ARController.cs
@@ -1112,7 +1112,9 @@ public class ARController : MonoBehaviour
                         PluginFunctions.arwUpdateTextureGL((int)_videoTexture0.GetNativeTexturePtr());
                     } else {
                         //Log(LogTag + "Calling GL.IssuePluginEvent");
+#pragma warning disable 618
                         GL.IssuePluginEvent((int)ARW_UNITY_RENDER_EVENTID.UPDATE_TEXTURE_GL);
+#pragma warning restore 618
                     }
                     
                 } else {
@@ -1183,7 +1185,9 @@ public class ARController : MonoBehaviour
                         PluginFunctions.arwUpdateTextureGLStereo((int)_videoTexture0.GetNativeTexturePtr(), (int)_videoTexture1.GetNativeTexturePtr());
                     } else {
                         //Log(LogTag + "Calling GL.IssuePluginEvent");
+#pragma warning disable 618
                         GL.IssuePluginEvent((int)ARW_UNITY_RENDER_EVENTID.UPDATE_TEXTURE_GL_STEREO);
+#pragma warning restore 618
                     }
 
                 } else {

--- a/src/Unity/Assets/ARToolKit5-Unity/Scripts/ARController.cs
+++ b/src/Unity/Assets/ARToolKit5-Unity/Scripts/ARController.cs
@@ -1322,7 +1322,7 @@ public class ARController : MonoBehaviour
         MeshFilter filter = vbmgo.AddComponent<MeshFilter>();
         filter.mesh = newVideoMesh(ContentFlipH, !ContentFlipV, textureScaleU, textureScaleV); // Invert flipV because ARToolKit video frame is top-down, Unity's is bottom-up.
         MeshRenderer meshRenderer = vbmgo.AddComponent<MeshRenderer>();
-        meshRenderer.castShadows = false;
+        meshRenderer.shadowCastingMode = UnityEngine.Rendering.ShadowCastingMode.Off;
         meshRenderer.receiveShadows = false;
         vbmgo.GetComponent<Renderer>().material = vbm;
         

--- a/src/Unity/Assets/ARToolKit5-Unity/Scripts/ARController.cs
+++ b/src/Unity/Assets/ARToolKit5-Unity/Scripts/ARController.cs
@@ -738,8 +738,8 @@ public class ARController : MonoBehaviour
                 // tell the native plugin the texture ID in advance, so do that now.
                 if (_useNativeGLTexturing) {
                     if (Application.platform != RuntimePlatform.IPhonePlayer && Application.platform != RuntimePlatform.Android) {
-                        if (!VideoIsStereo) PluginFunctions.arwSetUnityRenderEventUpdateTextureGLTextureID(_videoTexture0.GetNativeTextureID());
-                        else PluginFunctions.arwSetUnityRenderEventUpdateTextureGLStereoTextureIDs(_videoTexture0.GetNativeTextureID(), _videoTexture1.GetNativeTextureID());
+                        if (!VideoIsStereo) PluginFunctions.arwSetUnityRenderEventUpdateTextureGLTextureID((int)_videoTexture0.GetNativeTexturePtr());
+                        else PluginFunctions.arwSetUnityRenderEventUpdateTextureGLStereoTextureIDs((int)_videoTexture0.GetNativeTexturePtr(), (int)_videoTexture1.GetNativeTexturePtr());
                     }
                 }
 
@@ -1109,7 +1109,7 @@ public class ARController : MonoBehaviour
                     // As of 2013-09-23, mobile platforms don't support GL.IssuePluginEvent().
                     // See http://docs.unity3d.com/Documentation/Manual/NativePluginInterface.html.
                     if (Application.platform == RuntimePlatform.IPhonePlayer || Application.platform == RuntimePlatform.Android) {
-                        PluginFunctions.arwUpdateTextureGL(_videoTexture0.GetNativeTextureID());
+                        PluginFunctions.arwUpdateTextureGL((int)_videoTexture0.GetNativeTexturePtr());
                     } else {
                         //Log(LogTag + "Calling GL.IssuePluginEvent");
                         GL.IssuePluginEvent((int)ARW_UNITY_RENDER_EVENTID.UPDATE_TEXTURE_GL);
@@ -1180,7 +1180,7 @@ public class ARController : MonoBehaviour
                     // As of 2013-09-23, mobile platforms don't support GL.IssuePluginEvent().
                     // See http://docs.unity3d.com/Documentation/Manual/NativePluginInterface.html.
                     if (Application.platform == RuntimePlatform.IPhonePlayer || Application.platform == RuntimePlatform.Android) {
-                        PluginFunctions.arwUpdateTextureGLStereo(_videoTexture0.GetNativeTextureID(), _videoTexture1.GetNativeTextureID());
+                        PluginFunctions.arwUpdateTextureGLStereo((int)_videoTexture0.GetNativeTexturePtr(), (int)_videoTexture1.GetNativeTexturePtr());
                     } else {
                         //Log(LogTag + "Calling GL.IssuePluginEvent");
                         GL.IssuePluginEvent((int)ARW_UNITY_RENDER_EVENTID.UPDATE_TEXTURE_GL_STEREO);


### PR DESCRIPTION
This resolves (18) warnings from deprecation in newer versions of Unity.
Tested with Unity 5.3.5.f1 (and 5.4.0b22 beta).