### PR TITLE
Add option to set content alignment in the editor.

### DIFF
--- a/src/Unity/Assets/ARToolKit5-Unity/Scripts/Editor/ARControllerEditor.cs
+++ b/src/Unity/Assets/ARToolKit5-Unity/Scripts/Editor/ARControllerEditor.cs
@@ -111,6 +111,13 @@ public class ARControllerEditor : Editor
 			if (newContentMode != currentContentMode) {
 				arcontroller.ContentMode = newContentMode;
 			}
+			
+			ContentAlign currentContentAlign = arcontroller.ContentAlign;
+			ContentAlign newContentAlign = (ContentAlign)EditorGUILayout.EnumPopup("Content align", currentContentAlign);
+			if (newContentAlign != currentContentAlign) {
+				arcontroller.ContentAlign = newContentAlign;
+			}
+			
 			arcontroller.ContentRotate90 = EditorGUILayout.Toggle("Rotate 90 deg.", arcontroller.ContentRotate90);
 			arcontroller.ContentFlipV = EditorGUILayout.Toggle("Flip vertically", arcontroller.ContentFlipV);
 			arcontroller.ContentFlipH = EditorGUILayout.Toggle("Flip horizontally.", arcontroller.ContentFlipH);


### PR DESCRIPTION
The editor is missing an option to set the content alignment. Since it is not trivial to set the content always fill the screen, especially in case of mobile devices, content alignment is an important aspect for UI design and I believe should be included in the editor options.